### PR TITLE
Missing `end` on line:42. Syntax Error line:55 fix.

### DIFF
--- a/spec/06_patient_spec.rb
+++ b/spec/06_patient_spec.rb
@@ -39,6 +39,7 @@ describe 'Patient' do
       expect(steve.appointments).to include(appointment_one)
       expect(steve.appointments).to include(appointment_two)
     end
+  end
 
   describe '#doctors' do
     it 'has many doctors through appointments' do


### PR DESCRIPTION
Tests complains about a syntax error on line:55. It's a missing `end` on line:42