### PR TITLE
add end to fix 06_patient_spec.rb:55: syntax error, unexpected end-of…

### DIFF
--- a/spec/06_patient_spec.rb
+++ b/spec/06_patient_spec.rb
@@ -39,6 +39,7 @@ describe 'Patient' do
       expect(steve.appointments).to include(appointment_one)
       expect(steve.appointments).to include(appointment_two)
     end
+  end
 
   describe '#doctors' do
     it 'has many doctors through appointments' do


### PR DESCRIPTION
@
replicated error on my local, full error below

brought to my attention by https://learn.co/tracks/full-stack-web-development-v6/object-oriented-ruby/object-relationships/has-many-objects-through-lab?batch_id=306&question_id=152444&track_id=43149

error:
/Users/jamesrogers/.rvm/gems/ruby-2.3.3/gems/rspec-core-3.3.2/lib/rspec/core/configuration.rb:1327:in `load': /Users/jamesrogers/Dev/learn-labs/ruby-objects-has-many-through-lab-v-000/spec/06_patient_spec.rb:55: syntax error, unexpected end-of-input, expecting keyword_end (SyntaxError)
	from /Users/jamesrogers/.rvm/gems/ruby-2.3.3/gems/rspec-core-3.3.2/lib/rspec/core/configuration.rb:1327:in `block in load_spec_files'
	from /Users/jamesrogers/.rvm/gems/ruby-2.3.3/gems/rspec-core-3.3.2/lib/rspec/core/configuration.rb:1325:in `each'
	from /Users/jamesrogers/.rvm/gems/ruby-2.3.3/gems/rspec-core-3.3.2/lib/rspec/core/configuration.rb:1325:in `load_spec_files'
	from /Users/jamesrogers/.rvm/gems/ruby-2.3.3/gems/rspec-core-3.3.2/lib/rspec/core/runner.rb:102:in `setup'
	from /Users/jamesrogers/.rvm/gems/ruby-2.3.3/gems/rspec-core-3.3.2/lib/rspec/core/runner.rb:88:in `run'
	from /Users/jamesrogers/.rvm/gems/ruby-2.3.3/gems/rspec-core-3.3.2/lib/rspec/core/runner.rb:73:in `run'
	from /Users/jamesrogers/.rvm/gems/ruby-2.3.3/gems/rspec-core-3.3.2/lib/rspec/core/runner.rb:41:in `invoke'
	from /Users/jamesrogers/.rvm/gems/ruby-2.3.3/gems/rspec-core-3.3.2/exe/rspec:4:in `<top (required)>'
	from /Users/jamesrogers/.rvm/gems/ruby-2.3.3/bin/rspec:23:in `load'
	from /Users/jamesrogers/.rvm/gems/ruby-2.3.3/bin/rspec:23:in `<main>'
	from /Users/jamesrogers/.rvm/gems/ruby-2.3.3/bin/ruby_executable_hooks:24:in `eval'
	from /Users/jamesrogers/.rvm/gems/ruby-2.3.3/bin/ruby_executable_hooks:24:in `<main>'